### PR TITLE
[4.x] Fixing `upload` Image Editor Modal Collision

### DIFF
--- a/src/Components/Form/Upload/BrowserTest.php
+++ b/src/Components/Form/Upload/BrowserTest.php
@@ -314,6 +314,40 @@ class BrowserTest extends BrowserTestCase
     }
 
     #[Test]
+    public function can_open_the_editor_of_the_right_upload_when_the_property_repeats(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            use WithFileUploads;
+
+            public mixed $photo = null;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <x-upload label="Crop" wire:model="photo" editor="crop" />
+                    <div dusk="second">
+                        <x-upload label="Rotate" wire:model="photo" editor="rotate" />
+                    </div>
+                </div>
+                HTML;
+            }
+        })
+            ->assertPresent('#upload-editor-photo')
+            ->assertPresent('#upload-editor-photo-2')
+            ->click('[dusk=second] [dusk=tallstackui_upload_input]')
+            ->waitForText('Click here to upload')
+            ->attach('[dusk=tallstackui_upload_floating]:not([style*="display: none"]) [dusk=tallstackui_file_select]', __DIR__.'/test.jpeg')
+            ->waitFor('#upload-editor-photo-2 [dusk=tallstackui_upload_editor]')
+            ->waitUntil("document.querySelector('#upload-editor-photo-2 [dusk=tallstackui_upload_editor_canvas]').width > 0")
+            ->assertVisible('#upload-editor-photo-2 [dusk=tallstackui_upload_editor_rotate_left]')
+            ->assertMissing('#upload-editor-photo [dusk=tallstackui_upload_editor]')
+            // An untouched canvas keeps the 300px default width: the first editor never painted.
+            ->assertScript("document.querySelector('#upload-editor-photo [dusk=tallstackui_upload_editor_canvas]').width", 300);
+    }
+
+    #[Test]
     public function can_rotate_an_image_before_uploading(): void
     {
         Livewire::visit($this->editable())

--- a/src/Support/Miscellaneous/UploadEditorOptions.php
+++ b/src/Support/Miscellaneous/UploadEditorOptions.php
@@ -2,7 +2,9 @@
 
 namespace TallStackUi\Support\Miscellaneous;
 
+use Livewire\Component;
 use TallStackUi\TallStackUiComponent;
+use WeakMap;
 
 class UploadEditorOptions
 {
@@ -10,12 +12,16 @@ class UploadEditorOptions
 
     private const MODES = ['crop', 'rotate'];
 
+    // A WeakMap so the counters die with the render that created them.
+    private static ?WeakMap $sequences = null;
+
     public function __construct(
         private readonly TallStackUiComponent $component,
         private readonly bool|string|null $editor,
         private readonly ?string $aspect,
         private readonly array $configuration,
         private readonly string $id,
+        private readonly ?Component $livewire = null,
     ) {
         //
     }
@@ -47,13 +53,31 @@ class UploadEditorOptions
         [$width, $height] = $aspect ? array_map('intval', explode(':', $aspect)) : [null, null];
 
         return [
-            // The client opens the modal through window events named after its id.
-            'modal' => str('upload-editor-'.$this->id)->slug()->toString(),
+            'modal' => $this->modal(),
             'crop' => $editor === true || $editor === 'crop',
             'rotate' => $editor === true || $editor === 'rotate',
             'aspect' => $aspect ? $width / $height : null,
             'quality' => (float) ($this->configuration['quality'] ?? 0.92),
             'format' => $format,
         ];
+    }
+
+    // The client reaches the modal by id through window events, so two uploads
+    // bound to the same property need distinct ids. The render order is the
+    // same on every render of a component, so the suffix survives Livewire updates.
+    private function modal(): string
+    {
+        self::$sequences ??= new WeakMap;
+
+        $scope = $this->livewire ?? request();
+
+        $sequences = self::$sequences[$scope] ?? [];
+        $sequences[$this->id] = ($sequences[$this->id] ?? 0) + 1;
+
+        self::$sequences[$scope] = $sequences;
+
+        $sequence = $sequences[$this->id];
+
+        return str('upload-editor-'.$this->id.($sequence > 1 ? '-'.$sequence : ''))->slug()->toString();
     }
 }

--- a/src/Support/Runtime/Components/EditorRuntime.php
+++ b/src/Support/Runtime/Components/EditorRuntime.php
@@ -107,7 +107,7 @@ class EditorRuntime extends AbstractRuntime
 
         $configuration = __ts_get_component_configuration(Component::class)['upload'] ?? [];
 
-        return (new UploadEditorOptions($component, $component->uploadEditor, $component->uploadAspect, $configuration, $id))();
+        return (new UploadEditorOptions($component, $component->uploadEditor, $component->uploadAspect, $configuration, $id, $this->livewire))();
     }
 
     /** Flatten the toolbar into buttons and dividers the view can loop over. */

--- a/src/Support/Runtime/Components/UploadAsyncRuntime.php
+++ b/src/Support/Runtime/Components/UploadAsyncRuntime.php
@@ -65,7 +65,7 @@ class UploadAsyncRuntime extends AbstractRuntime
                 'accept' => $component->accept ?? $configuration['accept'],
             ],
             'i18n' => trans('ts-ui::messages.upload_async'),
-            'editing' => (new UploadEditorOptions($component, $component->editor, $component->aspect, $configuration, $id))(),
+            'editing' => (new UploadEditorOptions($component, $component->editor, $component->aspect, $configuration, $id, $this->livewire))(),
         ];
     }
 

--- a/src/Support/Runtime/Components/UploadRuntime.php
+++ b/src/Support/Runtime/Components/UploadRuntime.php
@@ -28,7 +28,7 @@ class UploadRuntime extends AbstractRuntime
                 'status' => $this->errors->has(is_array($value) ? $property.'.*' : $property),
                 'quantity' => count($this->errors->get(is_array($value) ? $property.'.*' : $property)),
             ],
-            'editing' => (new UploadEditorOptions($component, $component->editor, $component->aspect, __ts_get_component_configuration(Component::class) ?? [], (string) $bind->get('id')))(),
+            'editing' => (new UploadEditorOptions($component, $component->editor, $component->aspect, __ts_get_component_configuration(Component::class) ?? [], (string) $bind->get('id'), $this->livewire))(),
         ];
 
         if (is_null($property)) {


### PR DESCRIPTION
### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

Two `<x-upload>`, `<x-upload.async>` or `<x-editor>` instances bound to the same property on the same page rendered image editor modals with the same id, so opening one opened both and the image was painted in the first while the one on top stayed empty. Each instance now receives a unique modal id, suffixed by its render order within the Livewire component, which is stable across Livewire updates. No public API change, nothing to document.

### Demonstration & Notes:

```blade
<x-upload wire:model="photo" editor="crop" />
<x-upload wire:model="photo" editor="rotate" />
```