### PR TITLE
[4.x] Add `editor` Toolbar Tooltip Setting

### DIFF
--- a/.ai/components/editor.md
+++ b/.ai/components/editor.md
@@ -86,7 +86,7 @@ Twenty buttons across eight groups. Dividers are inserted automatically wherever
 
 Passing a slug the list does not know throws. On a viewport too narrow to hold the toolbar it scrolls horizontally rather than collapsing, so a customized order stays as it was written.
 
-Every button names itself through a tooltip, declared as `flash` so it opens on the tick the pointer arrives rather than after the default pause.
+Every button names itself through a tooltip, declared as `flash` so it opens on the tick the pointer arrives rather than after the default pause. The `style` and `align` triggers drop theirs while their dropdown is open, so the balloon never sits over the options. Set `toolbar_tooltip` to `false` in the [configuration](#configuration) to render the toolbar without any tooltip.
 
 Indentation outside a list is a `margin-left` on the block, in steps of 2rem up to eight levels. The native browser command reaches for a `<blockquote>` there, which is a quote rather than an indent and would be stripped by the sanitizer on the way back in. The block is rebuilt through `insertHTML` rather than having the margin written into it, so the step lands in the browser's undo stack and the caret is carried across.
 
@@ -341,6 +341,7 @@ The editable is a `role="textbox"` with `aria-multiline`, labelled by the `label
     'output_classes' => false,
     'output_classes_prefix' => null,
     'toolbar' => ['style', 'blockquote', 'bold', ..., 'redo', 'fullscreen'],
+    'toolbar_tooltip' => true,
     'counters' => true,
     'min_height' => '12rem',
     'max_height' => '40rem',

--- a/.ai/soft-customization-internal-scopes.md
+++ b/.ai/soft-customization-internal-scopes.md
@@ -67,9 +67,9 @@ TallStackUi::customize()
 
 | Scope                | Target           | Line(s) |
 |----------------------|------------------|---------|
-| `editor.toolbar`     | `<x-dropdown />` | 44, 223 |
-| `editor.modal.link`  | `<x-modal />`    | 456     |
-| `editor.modal.image` | `<x-modal />`    | 496     |
+| `editor.toolbar`     | `<x-dropdown />` | 43, 243 |
+| `editor.modal.link`  | `<x-modal />`    | 497     |
+| `editor.modal.image` | `<x-modal />`    | 537     |
 
 ### `form/autocomplete`
 

--- a/src/Components/Editor/BrowserTest.php
+++ b/src/Components/Editor/BrowserTest.php
@@ -481,6 +481,31 @@ class BrowserTest extends BrowserTestCase
     }
 
     #[Test]
+    public function can_hide_the_style_tooltip_while_the_dropdown_is_open(): void
+    {
+        Livewire::visit(new class extends LivewireComponent
+        {
+            public string $content = '<p>foo</p>';
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <x-editor wire:model="content" />
+                </div>
+                HTML;
+            }
+        })
+            ->waitUntil($this->booted())
+            ->mouseover('@tallstackui_editor_style')
+            ->waitFor('[data-tsui-tooltip][data-show]')
+            ->click('@tallstackui_editor_style')
+            ->waitUntilMissing('[data-tsui-tooltip][data-show]')
+            ->assertVisible('@tallstackui_editor_style')
+            ->assertAttribute('@tallstackui_editor_style', 'data-tooltip-disabled', 'true');
+    }
+
+    #[Test]
     public function can_indent_a_list_item(): void
     {
         Livewire::visit(new class extends LivewireComponent

--- a/src/Components/Editor/FeatureTest.php
+++ b/src/Components/Editor/FeatureTest.php
@@ -515,3 +515,25 @@ it('cannot render the image editor without the upload attributes', function () {
         ->render()
         ->not->toContain('tallstackui_upload_editor');
 });
+
+it('can render the toolbar tooltips by default', function () {
+    expect('<x-editor name="content" />')
+        ->render()
+        ->toContain('x-tooltip="Bold"')
+        ->toContain('x-bind:data-tooltip-disabled="show"');
+});
+
+it('can render without the toolbar tooltips', function () {
+    config()->set('ts-ui.components.editor.1.toolbar_tooltip', false);
+
+    __ts_get_component_configuration(Component::class, flush: true);
+
+    $html = expect('<x-editor name="content" />')->render();
+
+    $html->not->toContain('x-tooltip="Bold"')
+        ->not->toContain('x-bind:data-tooltip-disabled="show"');
+
+    config()->set('ts-ui.components.editor.1.toolbar_tooltip', true);
+
+    __ts_get_component_configuration(Component::class, flush: true);
+});

--- a/src/Support/Configurations/CompileConfigurations.php
+++ b/src/Support/Configurations/CompileConfigurations.php
@@ -197,6 +197,7 @@ class CompileConfigurations
             'output_classes_prefix' => $prefix,
             'output_classes' => EditorOutputClasses::of($component, $prefix),
             'toolbar' => $component->toolbar,
+            'toolbar_tooltip' => $configuration['toolbar_tooltip'] ?? true,
             'counters' => $component->counters,
             'placeholder' => $component->placeholder,
             'heights' => [

--- a/src/config.php
+++ b/src/config.php
@@ -448,6 +448,7 @@ return [
             | output_classes: stamps a class on every element the editor writes.
             | output_classes_prefix: the namespace of those names, ending with a dash. Null keeps "tsui-editor-".
             | toolbar: the canonical buttons and the order they are rendered in.
+            | toolbar_tooltip: displays a tooltip while hovering the toolbar buttons.
             | counters: displays the word and line counters in the footer.
             | min_height, max_height: the editable boundaries, in any CSS unit.
             | upload: the constraints checked in the browser before uploading, and the
@@ -471,6 +472,7 @@ return [
                     'undo', 'redo',
                     'fullscreen',
                 ],
+                'toolbar_tooltip' => true,
                 'counters' => true,
                 'min_height' => '12rem',
                 'max_height' => '40rem',

--- a/src/resources/views/components/editor/main.blade.php
+++ b/src/resources/views/components/editor/main.blade.php
@@ -36,8 +36,7 @@
                  class="{{ $customization['toolbar.wrapper'] }}">
                 @foreach ($layout as $item)
                     @if ($item['type'] === 'divider')
-                        <div aria-hidden="true" data-tsui-editor-divider
-                             class="{{ $customization['toolbar.divider'] }}"></div>
+                        <div aria-hidden="true" data-tsui-editor-divider class="{{ $customization['toolbar.divider'] }}"></div>
                     @else
                         @switch($item['slug'])
                             @case('style')
@@ -49,9 +48,12 @@
                                                 x-on:click="capture(); show = !show"
                                                 x-bind:aria-expanded="show"
                                                 aria-haspopup="true"
-                                                x-tooltip="{{ $i18n['tooltip']['style'] }}"
-                                                data-position="bottom"
-                                                data-tooltip-delay="flash"
+                                                @if ($configurations['toolbar_tooltip'])
+                                                    x-tooltip="{{ $i18n['tooltip']['style'] }}"
+                                                    data-position="bottom"
+                                                    data-tooltip-delay="flash"
+                                                    x-bind:data-tooltip-disabled="show"
+                                                @endif
                                                 dusk="tallstackui_editor_style"
                                                 class="{{ $customization['toolbar.dropdown.trigger'] }}">
                                             <span x-text="blockLabel()"></span>
@@ -83,9 +85,11 @@
                                         x-on:click="toggleBlockquote()"
                                         x-bind:aria-pressed="activeFormats.blockquote"
                                         x-bind:class="{ @js($customization['toolbar.button.active']): activeFormats.blockquote }"
-                                        x-tooltip="{{ $i18n['tooltip']['blockquote'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['blockquote'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         dusk="tallstackui_editor_blockquote"
                                         class="{{ $customization['toolbar.button.base'] }}">
                                     <span class="font-serif text-base leading-none">&rdquo;</span>
@@ -98,9 +102,11 @@
                                         x-on:click="exec('bold')"
                                         x-bind:aria-pressed="activeFormats.bold"
                                         x-bind:class="{ @js($customization['toolbar.button.active']): activeFormats.bold }"
-                                        x-tooltip="{{ $i18n['tooltip']['bold'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['bold'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         data-tsui-shortcut="mod+b"
                                         dusk="tallstackui_editor_bold"
                                         class="{{ $customization['toolbar.button.base'] }}">
@@ -114,9 +120,11 @@
                                         x-on:click="exec('italic')"
                                         x-bind:aria-pressed="activeFormats.italic"
                                         x-bind:class="{ @js($customization['toolbar.button.active']): activeFormats.italic }"
-                                        x-tooltip="{{ $i18n['tooltip']['italic'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['italic'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         data-tsui-shortcut="mod+i"
                                         dusk="tallstackui_editor_italic"
                                         class="{{ $customization['toolbar.button.base'] }}">
@@ -130,9 +138,11 @@
                                         x-on:click="exec('underline')"
                                         x-bind:aria-pressed="activeFormats.underline"
                                         x-bind:class="{ @js($customization['toolbar.button.active']): activeFormats.underline }"
-                                        x-tooltip="{{ $i18n['tooltip']['underline'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['underline'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         data-tsui-shortcut="mod+u"
                                         dusk="tallstackui_editor_underline"
                                         class="{{ $customization['toolbar.button.base'] }}">
@@ -146,9 +156,11 @@
                                         x-on:click="exec('strikeThrough')"
                                         x-bind:aria-pressed="activeFormats.strikethrough"
                                         x-bind:class="{ @js($customization['toolbar.button.active']): activeFormats.strikethrough }"
-                                        x-tooltip="{{ $i18n['tooltip']['strikethrough'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['strikethrough'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         dusk="tallstackui_editor_strikethrough"
                                         class="{{ $customization['toolbar.button.base'] }}">
                                     <span class="line-through">S</span>
@@ -161,9 +173,11 @@
                                         x-on:click="exec('insertOrderedList')"
                                         x-bind:aria-pressed="activeFormats.orderedList"
                                         x-bind:class="{ @js($customization['toolbar.button.active']): activeFormats.orderedList }"
-                                        x-tooltip="{{ $i18n['tooltip']['ordered_list'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['ordered_list'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         dusk="tallstackui_editor_ordered_list"
                                         class="{{ $customization['toolbar.button.base'] }}">
                                     <x-dynamic-component :component="TallStackUi::prefix('icon')"
@@ -178,9 +192,11 @@
                                         x-on:click="exec('insertUnorderedList')"
                                         x-bind:aria-pressed="activeFormats.unorderedList"
                                         x-bind:class="{ @js($customization['toolbar.button.active']): activeFormats.unorderedList }"
-                                        x-tooltip="{{ $i18n['tooltip']['unordered_list'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['unordered_list'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         dusk="tallstackui_editor_unordered_list"
                                         class="{{ $customization['toolbar.button.base'] }}">
                                     <x-dynamic-component :component="TallStackUi::prefix('icon')"
@@ -193,9 +209,11 @@
                                 <button type="button"
                                         x-on:mousedown.prevent
                                         x-on:click="shiftIndent(1)"
-                                        x-tooltip="{{ $i18n['tooltip']['indent'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['indent'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         dusk="tallstackui_editor_indent"
                                         class="{{ $customization['toolbar.button.base'] }}">
                                     <x-dynamic-component :component="TallStackUi::prefix('icon')"
@@ -208,9 +226,11 @@
                                 <button type="button"
                                         x-on:mousedown.prevent
                                         x-on:click="shiftIndent(-1)"
-                                        x-tooltip="{{ $i18n['tooltip']['outdent'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['outdent'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         dusk="tallstackui_editor_outdent"
                                         class="{{ $customization['toolbar.button.base'] }}">
                                     <x-dynamic-component :component="TallStackUi::prefix('icon')"
@@ -228,9 +248,12 @@
                                                 x-on:click="capture(); show = !show"
                                                 x-bind:aria-expanded="show"
                                                 aria-haspopup="true"
-                                                x-tooltip="{{ $i18n['tooltip']['align'] }}"
-                                                data-position="bottom"
-                                                data-tooltip-delay="flash"
+                                                @if ($configurations['toolbar_tooltip'])
+                                                    x-tooltip="{{ $i18n['tooltip']['align'] }}"
+                                                    data-position="bottom"
+                                                    data-tooltip-delay="flash"
+                                                    x-bind:data-tooltip-disabled="show"
+                                                @endif
                                                 dusk="tallstackui_editor_align"
                                                 class="{{ $customization['toolbar.dropdown.trigger'] }}">
                                             <x-dynamic-component :component="TallStackUi::prefix('icon')"
@@ -254,9 +277,11 @@
                                         x-on:click="toggleCode()"
                                         x-bind:aria-pressed="activeFormats.code"
                                         x-bind:class="{ @js($customization['toolbar.button.active']): activeFormats.code }"
-                                        x-tooltip="{{ $i18n['tooltip']['code'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['code'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         dusk="tallstackui_editor_code"
                                         class="{{ $customization['toolbar.button.base'] }}">
                                     <x-dynamic-component :component="TallStackUi::prefix('icon')"
@@ -271,9 +296,11 @@
                                         x-on:click="toggleCodeBlock()"
                                         x-bind:aria-pressed="activeFormats.codeBlock"
                                         x-bind:class="{ @js($customization['toolbar.button.active']): activeFormats.codeBlock }"
-                                        x-tooltip="{{ $i18n['tooltip']['code_block'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['code_block'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         dusk="tallstackui_editor_code_block"
                                         class="{{ $customization['toolbar.button.base'] }}">
                                     <x-dynamic-component :component="TallStackUi::prefix('icon')"
@@ -286,9 +313,11 @@
                                 <button type="button"
                                         x-on:mousedown.prevent
                                         x-on:click="clearFormat()"
-                                        x-tooltip="{{ $i18n['tooltip']['clear_format'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['clear_format'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         data-tsui-shortcut="mod+backslash"
                                         dusk="tallstackui_editor_clear_format"
                                         class="{{ $customization['toolbar.button.base'] }}">
@@ -304,9 +333,11 @@
                                         x-on:click="openLink()"
                                         x-bind:aria-pressed="activeFormats.link"
                                         x-bind:class="{ @js($customization['toolbar.button.active']): activeFormats.link }"
-                                        x-tooltip="{{ $i18n['tooltip']['link'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['link'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         data-tsui-shortcut="mod+k"
                                         dusk="tallstackui_editor_link"
                                         class="{{ $customization['toolbar.button.base'] }}">
@@ -320,9 +351,11 @@
                                 <button type="button"
                                         x-on:mousedown.prevent
                                         x-on:click="openImage()"
-                                        x-tooltip="{{ $i18n['tooltip']['image'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['image'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         dusk="tallstackui_editor_image"
                                         class="{{ $customization['toolbar.button.base'] }}">
                                     <x-dynamic-component :component="TallStackUi::prefix('icon')"
@@ -335,9 +368,11 @@
                                 <button type="button"
                                         x-on:mousedown.prevent
                                         x-on:click="insertRule()"
-                                        x-tooltip="{{ $i18n['tooltip']['hr'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['hr'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         dusk="tallstackui_editor_hr"
                                         class="{{ $customization['toolbar.button.base'] }}">
                                     <x-dynamic-component :component="TallStackUi::prefix('icon')"
@@ -350,9 +385,11 @@
                                 <button type="button"
                                         x-on:mousedown.prevent
                                         x-on:click="exec('undo')"
-                                        x-tooltip="{{ $i18n['tooltip']['undo'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['undo'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         data-tsui-shortcut="mod+z"
                                         dusk="tallstackui_editor_undo"
                                         class="{{ $customization['toolbar.button.base'] }}">
@@ -366,9 +403,11 @@
                                 <button type="button"
                                         x-on:mousedown.prevent
                                         x-on:click="exec('redo')"
-                                        x-tooltip="{{ $i18n['tooltip']['redo'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['redo'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         data-tsui-shortcut="mod+shift+z"
                                         dusk="tallstackui_editor_redo"
                                         class="{{ $customization['toolbar.button.base'] }}">
@@ -384,9 +423,11 @@
                                         x-on:click="toggleFullscreen()"
                                         x-bind:aria-pressed="fullscreen"
                                         x-bind:class="{ @js($customization['toolbar.button.active']): fullscreen }"
-                                        x-tooltip="{{ $i18n['tooltip']['fullscreen'] }}"
-                                        data-position="bottom"
-                                        data-tooltip-delay="flash"
+                                        @if ($configurations['toolbar_tooltip'])
+                                            x-tooltip="{{ $i18n['tooltip']['fullscreen'] }}"
+                                            data-position="bottom"
+                                            data-tooltip-delay="flash"
+                                        @endif
                                         dusk="tallstackui_editor_fullscreen"
                                         class="{{ $customization['toolbar.button.base'] }}">
                                     <template x-if="!fullscreen">


### PR DESCRIPTION
### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

Adds the `toolbar_tooltip` key to the `editor` configuration (`true` by default). When `false`, the toolbar buttons of `<x-editor>` render without their hover tooltips. There is no inline prop, the setting is global.

The `style` and `align` dropdown triggers now disable their tooltip while the dropdown is open, so the balloon no longer sits over the options. No API change for that part.

### Demonstration & Notes:

```php
'editor' => [
    'toolbar_tooltip' => false,
],
```