### PR TITLE
[4.x] Add `layout.header` Collapse Icon Setting

### DIFF
--- a/.ai/components/layout/header.md
+++ b/.ai/components/layout/header.md
@@ -32,17 +32,18 @@ A sticky top header component for the application layout. Provides left, middle,
 
 ## Attributes
 
-| Attribute             | Type               | Default | Description                                      |
-|-----------------------|--------------------|---------|--------------------------------------------------|
-| left                  | slot\|string\|null | null    | Content rendered on the left side of the header  |
-| middle                | slot\|string\|null | null    | Content rendered in the center of the header     |
-| right                 | slot\|string\|null | null    | Content rendered on the right side of the header |
-| without-mobile-button | bool\|null         | null    | Hides the mobile hamburger menu toggle button    |
-| size                  | string\|null       | md      | Header height (`sm`, `md`, `lg`, `xl`)           |
-| sm                    | bool\|null         | null    | Shortcut for `size="sm"` (`h-14`)                |
-| md                    | bool\|null         | null    | Shortcut for `size="md"` (`h-16`)                |
-| lg                    | bool\|null         | null    | Shortcut for `size="lg"` (`h-20`)                |
-| xl                    | bool\|null         | null    | Shortcut for `size="xl"` (`h-24`)                |
+| Attribute             | Type               | Default | Description                                                                                                                 |
+|-----------------------|--------------------|---------|-----------------------------------------------------------------------------------------------------------------------------|
+| left                  | slot\|string\|null | null    | Content rendered on the left side of the header                                                                             |
+| middle                | slot\|string\|null | null    | Content rendered in the center of the header                                                                                |
+| right                 | slot\|string\|null | null    | Content rendered on the right side of the header                                                                            |
+| without-mobile-button | bool\|null         | null    | Hides the mobile hamburger menu toggle button                                                                               |
+| collapse-icon         | string\|null       | null    | Icon of the sidebar collapse toggle. Falls back to the `collapse-icon` config, then to the `collapse.icon` block (`bars-4`) |
+| size                  | string\|null       | md      | Header height (`sm`, `md`, `lg`, `xl`)                                                                                      |
+| sm                    | bool\|null         | null    | Shortcut for `size="sm"` (`h-14`)                                                                                           |
+| md                    | bool\|null         | null    | Shortcut for `size="md"` (`h-16`)                                                                                           |
+| lg                    | bool\|null         | null    | Shortcut for `size="lg"` (`h-20`)                                                                                           |
+| xl                    | bool\|null         | null    | Shortcut for `size="xl"` (`h-24`)                                                                                           |
 
 The `size` default comes from the global configuration, so it describes the shipped
 configuration rather than a value hardcoded in the component.
@@ -60,12 +61,15 @@ configuration rather than a value hardcoded in the component.
     \TallStackUi\Components\Layout\Header\Component::class,
     [
         'size' => 'md',
+        'collapse-icon' => null, // any icon name, e.g. chevron-double-left
     ],
 ],
 ```
 
 A shortcut flag wins over `size`, `size` wins over the configuration. An unknown
-size raises a validation exception, wherever it came from.
+size raises a validation exception, wherever it came from. The `collapse-icon`
+attribute wins over its configuration, and both win over the `collapse.icon`
+customization block, which stays the last fallback.
 
 ## Validation Constraints
 

--- a/src/Components/Layout/Header/Component.php
+++ b/src/Components/Layout/Header/Component.php
@@ -19,6 +19,7 @@ class Component extends TallStackUiComponent implements Customization
         public ComponentSlot|string|null $middle = null,
         public ComponentSlot|string|null $right = null,
         public ?bool $withoutMobileButton = null,
+        public ?string $collapseIcon = null,
         public ?string $size = null,
         public ?bool $sm = null,
         public ?bool $md = null,
@@ -67,6 +68,8 @@ class Component extends TallStackUiComponent implements Customization
 
     protected function setup(): void
     {
+        $this->collapseIcon ??= __ts_get_component_configuration(self::class, 'collapse-icon');
+
         $this->size = match (true) {
             $this->xl === true => 'xl',
             $this->lg === true => 'lg',

--- a/src/Components/Layout/Header/FeatureTest.php
+++ b/src/Components/Layout/Header/FeatureTest.php
@@ -19,7 +19,21 @@ function tallstackui_header_size(string $size): void
     __ts_get_component_configuration(Component::class, flush: true);
 }
 
-afterEach(fn () => tallstackui_header_size('md'));
+function tallstackui_header_collapse_icon(?string $icon): void
+{
+    $components = config('ts-ui.components');
+
+    $components['layout.header'][1]['collapse-icon'] = $icon;
+
+    config()->set('ts-ui.components', $components);
+
+    __ts_get_component_configuration(Component::class, flush: true);
+}
+
+afterEach(function () {
+    tallstackui_header_size('md');
+    tallstackui_header_collapse_icon(null);
+});
 
 it('can render', function () {
     $component = <<<'HTML'
@@ -104,4 +118,30 @@ it('cannot render with an invalid size', function () {
     $this->expectException(ViewException::class);
 
     expect('<x-layout.header size="2xl" />')->render();
+});
+
+it('can render the default collapse icon')
+    ->expect('<x-layout.header />')
+    ->render()
+    ->toContain('aria-label="Toggle sidebar"')
+    ->toContain('M3 5.25a.75.75');
+
+it('can render the collapse icon through the attribute', function () {
+    expect('<x-layout.header collapse-icon="chevron-double-left" />')->render()
+        ->toContain('M10.72 11.47a');
+});
+
+it('can render the collapse icon through the global configuration', function () {
+    tallstackui_header_collapse_icon('chevron-double-left');
+
+    expect('<x-layout.header />')->render()
+        ->toContain('M10.72 11.47a');
+});
+
+it('can suppress the global collapse icon through the attribute', function () {
+    tallstackui_header_collapse_icon('chevron-double-left');
+
+    expect('<x-layout.header collapse-icon="arrows-pointing-in" />')->render()
+        ->toContain('M3.22 3.22a.75')
+        ->not->toContain('M10.72 11.47a');
 });

--- a/src/config.php
+++ b/src/config.php
@@ -680,10 +680,12 @@ return [
             |----------------------------------------------------------------------
             |
             | size: controls the header height (Allowed: sm, md, lg, xl).
+            | collapse-icon: the icon of the sidebar collapse toggle. Null keeps the original (bars-4).
             |
             */
             [
                 'size' => 'md',
+                'collapse-icon' => null,
             ],
         ],
         'link' => [

--- a/src/resources/views/components/layout/header.blade.php
+++ b/src/resources/views/components/layout/header.blade.php
@@ -11,7 +11,7 @@
             aria-label="Toggle sidebar"
             class="{{ $customization['collapse.class'] }}">
         <x-dynamic-component :component="TallStackUi::prefix('icon')"
-                             :icon="TallStackUi::icon($customization['collapse.icon'])"
+                             :icon="TallStackUi::icon($collapseIcon ?? $customization['collapse.icon'])"
                              internal
                              class="{{ $customization['collapse.icon.size'] }}" />
     </button>


### PR DESCRIPTION
### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

### What:

- [x] Feature
- [ ] Enhancements
- [ ] Bugfix

### Description:

Adds the `collapse-icon` attribute to `<x-layout.header>` and the matching `collapse-icon` key to the `layout.header` configuration (`null` by default) to change the icon of the sidebar collapse toggle. Any icon name is accepted. The attribute wins over the configuration, and both win over the existing `collapse.icon` customization block, which keeps `bars-4` as the last fallback.

### Demonstration & Notes:

```blade
<x-layout.header collapse-icon="chevron-double-left" />
```

```php
'layout.header' => [
    'collapse-icon' => 'chevron-double-left',
],
```