### PR TITLE
[4.x] Fixing `password` Input Type Binding

### DIFF
--- a/src/Components/Form/Password/BrowserTest.php
+++ b/src/Components/Form/Password/BrowserTest.php
@@ -318,6 +318,30 @@ class BrowserTest extends BrowserTestCase
     }
 
     #[Test]
+    public function can_toggle_the_input_type_when_revealing(): void
+    {
+        Livewire::visit(new class extends Component
+        {
+            public ?string $password = null;
+
+            public function render(): string
+            {
+                return <<<'HTML'
+                <div>
+                    <x-password dusk="input" wire:model="password" />
+                </div>
+                HTML;
+            }
+        })
+            ->waitForLivewireToLoad()
+            ->assertScript('document.querySelector("[dusk=input]").type === "password"')
+            ->click('@tallstackui_form_password_reveal')
+            ->waitUntil('document.querySelector("[dusk=input]").type === "text"')
+            ->click('@tallstackui_form_password_reveal')
+            ->waitUntil('document.querySelector("[dusk=input]").type === "password"');
+    }
+
+    #[Test]
     public function can_use_a_custom_generator_rule(): void
     {
         Livewire::visit(new class extends Component

--- a/src/Components/Form/Password/FeatureTest.php
+++ b/src/Components/Form/Password/FeatureTest.php
@@ -70,3 +70,9 @@ it('does not render the generator button while locked, but keeps the reveal', fu
         ->not->toContain('tallstackui_form_password_generate')
         ->toContain('tallstackui_form_password_reveal');
 })->with(['readonly', 'disabled']);
+
+it('binds the input type with the explicit x-bind syntax')
+    ->expect('<x-password />')
+    ->render()
+    ->toContain('x-bind:type="!show ? \'password\' : \'text\'"')
+    ->not->toContain('::type');

--- a/src/resources/views/components/form/password.blade.php
+++ b/src/resources/views/components/form/password.blade.php
@@ -10,7 +10,7 @@
                          :$label
                          :$hint
                          :$invalidate
-                         ::type="!show ? 'password' : 'text'"
+                         x-bind:type="!show ? 'password' : 'text'"
                          floatable
                          autocomplete="{{ $attributes->get('autocomplete', 'off') }}"
                          x-on:paste="paste($event)"


### PR DESCRIPTION
### Checklist:

- [x] I read the [CONTRIBUTION GUIDE](https://tallstackui.com/docs/contribution)
- [x] I created a new branch on my fork for this pull request
- [x] I ensure that the current tests are passing
- [x] I added tests that prove this pull request is working

### What:

- [ ] Feature
- [ ] Enhancements
- [x] Bugfix

### Description:

The reveal button on `password` stopped switching the field between `password` and `text` when a Blade precompiler (livewire/blaze, for example) is installed. The template used the `::type` escape, the precompiler rewrote it as `:::type`, Laravel stripped one colon, and Alpine ended up binding an attribute called `:type` instead of `type`.

The template now uses `x-bind:type`, which is the same binding without the escape. Nothing changes in the public API and there is nothing new to document.

Fixes #1372.

### Demonstration & Notes:

Only shows up with a Blade precompiler in the app. A plain Laravel install already rendered `:type` correctly.